### PR TITLE
Fixes after merge of standard paths

### DIFF
--- a/dialog/aboutdialog.cpp
+++ b/dialog/aboutdialog.cpp
@@ -43,7 +43,7 @@ AboutDialog::AboutDialog(QDialog *parent) :
     buttonLayout->addSpacerItem(spacer2);
     mainLayout->addLayout(buttonLayout);
     this->setLayout(mainLayout);
-    QString file = global.fileManager.getProgramDirPath("") + "/help/about.html";
+    QString file = global.fileManager.getProgramDirPath() + "help/about.html";
     QFile f(file);
     if(!f.open(QFile::ReadOnly))
         return;

--- a/dialog/aboutdialog.cpp
+++ b/dialog/aboutdialog.cpp
@@ -43,7 +43,7 @@ AboutDialog::AboutDialog(QDialog *parent) :
     buttonLayout->addSpacerItem(spacer2);
     mainLayout->addLayout(buttonLayout);
     this->setLayout(mainLayout);
-    QString file = global.fileManager.getProgramDirPath() + "help/about.html";
+    QString file = global.fileManager.getProgramDataDir() + "help/about.html";
     QFile f(file);
     if(!f.open(QFile::ReadOnly))
         return;

--- a/dialog/accountmaintenancedialog.cpp
+++ b/dialog/accountmaintenancedialog.cpp
@@ -137,9 +137,9 @@ void AccountMaintenanceDialog::deleteAccount() {
             }
         }
     }
-    QFile configFile(global.fileManager.getHomeDirPath()+"nixnote-"+QString::number(id) +".conf");
+    QFile configFile(global.fileManager.getConfigDir()+"nixnote-"+QString::number(id) +".conf");
     configFile.remove();
-    removeDir(global.fileManager.getHomeDirPath()+QString("db-")+QString::number(id));
+    removeDir(global.fileManager.getConfigDir()+QString("db-")+QString::number(id));
 }
 
 void AccountMaintenanceDialog::renameAccount() {

--- a/dialog/accountmaintenancedialog.cpp
+++ b/dialog/accountmaintenancedialog.cpp
@@ -139,7 +139,7 @@ void AccountMaintenanceDialog::deleteAccount() {
     }
     QFile configFile(global.fileManager.getConfigDir()+"nixnote-"+QString::number(id) +".conf");
     configFile.remove();
-    removeDir(global.fileManager.getConfigDir()+QString("db-")+QString::number(id));
+    removeDir(global.fileManager.getUserDataDir()+QString("db-")+QString::number(id));
 }
 
 void AccountMaintenanceDialog::renameAccount() {

--- a/dialog/accountmaintenancedialog.cpp
+++ b/dialog/accountmaintenancedialog.cpp
@@ -137,9 +137,9 @@ void AccountMaintenanceDialog::deleteAccount() {
             }
         }
     }
-    QFile configFile(global.fileManager.getHomeDirPath("")+"nixnote-"+QString::number(id) +".conf");
+    QFile configFile(global.fileManager.getHomeDirPath()+"nixnote-"+QString::number(id) +".conf");
     configFile.remove();
-    removeDir(global.fileManager.getHomeDirPath("")+QString("db-")+QString::number(id));
+    removeDir(global.fileManager.getHomeDirPath()+QString("db-")+QString::number(id));
 }
 
 void AccountMaintenanceDialog::renameAccount() {

--- a/dialog/htmlentitiesdialog.cpp
+++ b/dialog/htmlentitiesdialog.cpp
@@ -186,7 +186,7 @@ void HtmlEntitiesDialog::editClicked() {
     if (editMode) {
         if (textEdit->document()->isModified()) {
             QString value = textEdit->toPlainText();
-            QString fileName = global.fileManager.getHomeDirPath() + QString("entities.txt");
+            QString fileName = global.fileManager.getConfigDir() + QString("entities.txt");
             QDir dir;
             dir.remove(fileName);
             QFile file(fileName);
@@ -259,7 +259,7 @@ void HtmlEntitiesDialog::getEntitiesList(QStringList *list, QString entitiesAsTe
 
 void HtmlEntitiesDialog::loadCustomEntities() {
     entities.clear();
-    QString fileName = global.fileManager.getHomeDirPath() + QString("entities.txt");
+    QString fileName = global.fileManager.getConfigDir() + QString("entities.txt");
     QFile file(fileName);
     file.open(QFile::ReadOnly);
     if (file.isOpen()) {

--- a/dialog/htmlentitiesdialog.cpp
+++ b/dialog/htmlentitiesdialog.cpp
@@ -186,7 +186,7 @@ void HtmlEntitiesDialog::editClicked() {
     if (editMode) {
         if (textEdit->document()->isModified()) {
             QString value = textEdit->toPlainText();
-            QString fileName = global.fileManager.getHomeDirPath("") + QString("entities.txt");
+            QString fileName = global.fileManager.getHomeDirPath() + QString("entities.txt");
             QDir dir;
             dir.remove(fileName);
             QFile file(fileName);
@@ -259,7 +259,7 @@ void HtmlEntitiesDialog::getEntitiesList(QStringList *list, QString entitiesAsTe
 
 void HtmlEntitiesDialog::loadCustomEntities() {
     entities.clear();
-    QString fileName = global.fileManager.getHomeDirPath("") + QString("entities.txt");
+    QString fileName = global.fileManager.getHomeDirPath() + QString("entities.txt");
     QFile file(fileName);
     file.open(QFile::ReadOnly);
     if (file.isOpen()) {

--- a/dialog/preferences/appearancepreferences.cpp
+++ b/dialog/preferences/appearancepreferences.cpp
@@ -323,11 +323,7 @@ void AppearancePreferences::saveValues() {
         // Ideally, we could use QSettings since it is ini format, but
         // it puts [Desktop Entry] as [Desktop%20Enry], which screws
         // things up.
-#ifdef USE_QSP
         QString systemFile = QLibraryInfo::location(QLibraryInfo::PrefixPath) + "/share/applications/nixnote2.desktop";
-#else
-        QString systemFile = "/usr/share/applications/nixnote2.desktop";
-#endif
         QFile systemIni(systemFile);
         QStringList desktopData;
 
@@ -374,11 +370,7 @@ void AppearancePreferences::saveValues() {
         QFile::link(QCoreApplication::applicationFilePath(), QDesktopServices::storageLocation(QDesktopServices::ApplicationsLocation) + QDir::separator() + "Startup" + QDir::separator() + fileInfo.completeBaseName() + ".lnk");
 #elif !defined(__APPLE__)
         //Copy the nixnote2.desktop to the ~/.config/autostart directory
-#ifdef USE_QSP
         QString systemFile = QLibraryInfo::location(QLibraryInfo::PrefixPath) + "/share/applications/nixnote2.desktop";
-#else
-        QString systemFile = "/usr/share/applications/nixnote2.desktop";
-#endif
         QFile systemIni(systemFile);
         QStringList desktopData;
 

--- a/dialog/preferences/emailpreferences.cpp
+++ b/dialog/preferences/emailpreferences.cpp
@@ -152,12 +152,13 @@ void EmailPreferences::sendTestEmail() {
       QString msg = QString(tr("<h1>This is a test email from NixNote.</h1> "));
       msg = msg + QString(tr("If you are reading it then your email preferences are are setup properly."));
       html.setHtml(msg);
-//    QFile *logo = new QFile(global.fileManager.getProgramDirPath("")+"splash_logo.png");
+//    QFile *logo = new QFile(global.fileManager.getProgramDirPath()+"splash_logo.png");
 //    MimeInlineFile image1(logo);
 //    image1.setContentType("image/png");
 //    image1.setContentId("image1");
 //    message.addPart(&html);
 //    message.addPart(&image1);
+
       message.setContent(&html);
 
 

--- a/dialog/preferences/emailpreferences.cpp
+++ b/dialog/preferences/emailpreferences.cpp
@@ -152,7 +152,7 @@ void EmailPreferences::sendTestEmail() {
       QString msg = QString(tr("<h1>This is a test email from NixNote.</h1> "));
       msg = msg + QString(tr("If you are reading it then your email preferences are are setup properly."));
       html.setHtml(msg);
-//    QFile *logo = new QFile(global.fileManager.getProgramDirPath()+"splash_logo.png");
+//    QFile *logo = new QFile(global.fileManager.getProgramDataDir()+"splash_logo.png");
 //    MimeInlineFile image1(logo);
 //    image1.setContentType("image/png");
 //    image1.setContentId("image1");

--- a/global.cpp
+++ b/global.cpp
@@ -158,7 +158,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     settingsFile = fileManager.getConfigDir() + "nixnote-"+QString::number(accountId)+".conf";
     settings = new QSettings(settingsFile, QSettings::IniFormat);
 
-    if (startupConfig.getLogLevel() == 0) {
+    if (startupConfig.getLogLevel() < 0) {
         // set log level from conf file, but only if it was not already se on command line
         setDebugLevelBySetting();
     }
@@ -1449,6 +1449,7 @@ void Global::setDebugLevelBySetting() {
     settings->beginGroup("Debugging");
     int level = settings->value("messageLevel", -1).toInt();
     settings->endGroup();
+    QLOG_INFO() << "Changed logLevel via settings to " << level;
     setDebugLevel(level);
 }
 

--- a/global.cpp
+++ b/global.cpp
@@ -133,7 +133,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     const QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/";
     QString settingsFile = configDir + "nixnote.conf";
 #else
-    QString settingsFile = fileManager.getHomeDirPath("") + "nixnote.conf";
+    QString settingsFile = fileManager.getHomeDirPath() + "nixnote.conf";
 #endif
 
     globalSettings = new QSettings(settingsFile, QSettings::IniFormat);
@@ -159,7 +159,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
 #ifdef USE_QSP
     settingsFile = configDir + "nixnote-"+QString::number(accountId)+".conf";
 #else
-    settingsFile = fileManager.getHomeDirPath("") + "nixnote-"+QString::number(accountId)+".conf";
+    settingsFile = fileManager.getHomeDirPath() + "nixnote-"+QString::number(accountId)+".conf";
 #endif
 
     settings = new QSettings(settingsFile, QSettings::IniFormat);
@@ -272,27 +272,6 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     exitManager = new ExitManager();
     exitManager->loadExits();
 }
-
-
-// Return the path the program is executing under
-// If we are in /usr/bin, then we need to return /usr/share/nixnote2.
-// This is because we want to find other paths (like images).  This
-// allows for users to run it out of a non-path location.
-QString Global::getProgramDirPath() {
-#ifdef USE_QSP
-    // FileManager::getProgramDirPath() already returns exactly what
-    // we want to return ourselves.
-    return fileManager.getProgramDirPath("");
-#else
-    QString path = QCoreApplication::applicationDirPath();
-    if (path.endsWith("/bin")) {
-        path.chop(3);
-        return path+"share/nixnote2";
-    }
-    return path;
-#endif
-}
-
 
 void Global::setDeleteConfirmation(bool value) {
     settings->beginGroup("Appearance");
@@ -1115,22 +1094,10 @@ void Global::loadTheme(QHash<QString, QString> &resourceList, QHash<QString,QStr
     colorList.clear();
     if (theme.trimmed() == "")
         return;
-#ifndef _WIN32
-    QFile systemTheme(fileManager.getProgramDirPath("theme.ini"));
-#else
-    QFile systemTheme(fileManager.getProgramDirPath("theme.ini").replace("\\","/"));
-#endif
-    this->loadThemeFile(resourceList,colorList, systemTheme, theme);
+    QFile systemTheme(fileManager.getProgramDirPath() + "theme.ini");
+    this->loadThemeFile(resourceList, colorList, systemTheme, theme);
 
-#ifndef _WIN32
-#ifdef USE_QSP
-    QFile userTheme(QStandardPaths::locate(QStandardPaths::AppConfigLocation, "theme.ini"));
-#else
-    QFile userTheme(fileManager.getHomeDirPath("theme.ini"));
-#endif
-#else
-    QFile userTheme(fileManager.getHomeDirPath("theme.ini").replace("\\","/"));
-#endif
+    QFile userTheme(fileManager.getHomeDirPath() + "theme.ini");
     this->loadThemeFile(resourceList, colorList, userTheme, theme);
 }
 
@@ -1189,22 +1156,12 @@ void Global::loadThemeFile(QHash<QString,QString> &resourceList, QHash<QString,Q
 QStringList Global::getThemeNames() {
     QStringList values;
     values.empty();
-#ifndef _WIN32
-    QFile systemTheme(fileManager.getProgramDirPath("theme.ini"));
-#else
-    QFile systemTheme(fileManager.getProgramDirPath("theme.ini").replace("\\","/"));
-#endif
+    QFile systemTheme(fileManager.getProgramDirPath() + "theme.ini");
     this->getThemeNamesFromFile(systemTheme, values);
-#ifndef _WIN32
-#ifdef USE_QSP
-    QFile userTheme(QStandardPaths::locate(QStandardPaths::AppConfigLocation, "theme.ini"));
-#else
-    QFile userTheme(fileManager.getHomeDirPath("theme.ini"));
-#endif
-#else
-    QFile userTheme(fileManager.getHomeDirPath("theme.ini").replace("\\","/"));
-#endif
-        this->getThemeNamesFromFile(userTheme, values);
+
+    QFile userTheme(fileManager.getHomeDirPath() + "theme.ini");
+    this->getThemeNamesFromFile(userTheme, values);
+
     if (!nonAsciiSortBug)
         qSort(values.begin(), values.end(), caseInsensitiveLessThan);
 

--- a/global.cpp
+++ b/global.cpp
@@ -133,7 +133,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     const QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/";
     QString settingsFile = configDir + "nixnote.conf";
 #else
-    QString settingsFile = fileManager.getHomeDirPath() + "nixnote.conf";
+    QString settingsFile = fileManager.getConfigDir() + "nixnote.conf";
 #endif
 
     globalSettings = new QSettings(settingsFile, QSettings::IniFormat);
@@ -159,7 +159,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
 #ifdef USE_QSP
     settingsFile = configDir + "nixnote-"+QString::number(accountId)+".conf";
 #else
-    settingsFile = fileManager.getHomeDirPath() + "nixnote-"+QString::number(accountId)+".conf";
+    settingsFile = fileManager.getConfigDir() + "nixnote-"+QString::number(accountId)+".conf";
 #endif
 
     settings = new QSettings(settingsFile, QSettings::IniFormat);
@@ -1094,10 +1094,10 @@ void Global::loadTheme(QHash<QString, QString> &resourceList, QHash<QString,QStr
     colorList.clear();
     if (theme.trimmed() == "")
         return;
-    QFile systemTheme(fileManager.getProgramDirPath() + "theme.ini");
+    QFile systemTheme(fileManager.getProgramDataDir() + "theme.ini");
     this->loadThemeFile(resourceList, colorList, systemTheme, theme);
 
-    QFile userTheme(fileManager.getHomeDirPath() + "theme.ini");
+    QFile userTheme(fileManager.getConfigDir() + "theme.ini");
     this->loadThemeFile(resourceList, colorList, userTheme, theme);
 }
 
@@ -1156,10 +1156,10 @@ void Global::loadThemeFile(QHash<QString,QString> &resourceList, QHash<QString,Q
 QStringList Global::getThemeNames() {
     QStringList values;
     values.empty();
-    QFile systemTheme(fileManager.getProgramDirPath() + "theme.ini");
+    QFile systemTheme(fileManager.getProgramDataDir() + "theme.ini");
     this->getThemeNamesFromFile(systemTheme, values);
 
-    QFile userTheme(fileManager.getHomeDirPath() + "theme.ini");
+    QFile userTheme(fileManager.getConfigDir() + "theme.ini");
     this->getThemeNamesFromFile(userTheme, values);
 
     if (!nonAsciiSortBug)

--- a/global.cpp
+++ b/global.cpp
@@ -123,18 +123,18 @@ Global::Global()
 
 
 
-//Initial global settings setup
+// Initial global settings setup
 void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     this->guiAvailable = guiAvailable;
-    fileManager.setup(startupConfig.getConfigDir(), startupConfig.getProgramDir(), startupConfig.getAccountId());
+    fileManager.setup(
+        startupConfig.getConfigDir(),
+        startupConfig.getUserDataDir(),
+        startupConfig.getProgramDataDir(),
+        startupConfig.getAccountId());
 
     shortcutKeys = new ShortcutKeys();
-#ifdef USE_QSP
-    const QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/";
-    QString settingsFile = configDir + "nixnote.conf";
-#else
     QString settingsFile = fileManager.getConfigDir() + "nixnote.conf";
-#endif
+    QLOG_DEBUG() << "Global::setup settingsFile: " << settingsFile;
 
     globalSettings = new QSettings(settingsFile, QSettings::IniFormat);
     int accountId = startupConfig.getAccountId();
@@ -155,16 +155,13 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     key = key+QString::number(accountId);
     sharedMemory = new CrossMemoryMapper(key);
 
-
-#ifdef USE_QSP
-    settingsFile = configDir + "nixnote-"+QString::number(accountId)+".conf";
-#else
     settingsFile = fileManager.getConfigDir() + "nixnote-"+QString::number(accountId)+".conf";
-#endif
-
     settings = new QSettings(settingsFile, QSettings::IniFormat);
 
-    setDebugLevelBySetting();
+    if (startupConfig.getLogLevel() == 0) {
+        // set log level from conf file, but only if it was not already se on command line
+        setDebugLevelBySetting();
+    }
 
     this->forceNoStartMimized = startupConfig.forceNoStartMinimized;
     this->forceSystemTrayAvailable = startupConfig.forceSystemTrayAvailable;
@@ -1097,7 +1094,7 @@ void Global::loadTheme(QHash<QString, QString> &resourceList, QHash<QString,QStr
     QFile systemTheme(fileManager.getProgramDataDir() + "theme.ini");
     this->loadThemeFile(resourceList, colorList, systemTheme, theme);
 
-    QFile userTheme(fileManager.getConfigDir() + "theme.ini");
+    QFile userTheme(fileManager.getConfigDir() + "theme.ini"); // user theme
     this->loadThemeFile(resourceList, colorList, userTheme, theme);
 }
 
@@ -1159,7 +1156,7 @@ QStringList Global::getThemeNames() {
     QFile systemTheme(fileManager.getProgramDataDir() + "theme.ini");
     this->getThemeNamesFromFile(systemTheme, values);
 
-    QFile userTheme(fileManager.getConfigDir() + "theme.ini");
+    QFile userTheme(fileManager.getConfigDir() + "theme.ini"); // user theme
     this->getThemeNamesFromFile(userTheme, values);
 
     if (!nonAsciiSortBug)

--- a/global.cpp
+++ b/global.cpp
@@ -126,7 +126,8 @@ Global::Global()
 //Initial global settings setup
 void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     this->guiAvailable = guiAvailable;
-    fileManager.setup(startupConfig.homeDirPath, startupConfig.programDirPath, startupConfig.accountId);
+    fileManager.setup(startupConfig.getConfigDir(), startupConfig.getProgramDir(), startupConfig.getAccountId());
+
     shortcutKeys = new ShortcutKeys();
 #ifdef USE_QSP
     const QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/";
@@ -136,7 +137,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
 #endif
 
     globalSettings = new QSettings(settingsFile, QSettings::IniFormat);
-    int accountId = startupConfig.accountId;
+    int accountId = startupConfig.getAccountId();
     if (accountId <=0) {
         globalSettings->beginGroup("SaveState");
         accountId = globalSettings->value("lastAccessedAccount", 1).toInt();
@@ -163,7 +164,7 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
 
     settings = new QSettings(settingsFile, QSettings::IniFormat);
 
-    setDebugLevel();
+    setDebugLevelBySetting();
 
     this->forceNoStartMimized = startupConfig.forceNoStartMinimized;
     this->forceSystemTrayAvailable = startupConfig.forceSystemTrayAvailable;
@@ -171,8 +172,8 @@ void Global::setup(StartupConfig startupConfig, bool guiAvailable) {
     //this->syncAndExit = startupConfig.syncAndExit;
     this->forceStartMinimized = startupConfig.forceStartMinimized;
     this->startupNote = startupConfig.startupNoteLid;
-    startupConfig.accountId = accountId;
-    accountsManager = new AccountsManager(startupConfig.accountId);
+    startupConfig.setAccountId(accountId);
+    accountsManager = new AccountsManager(startupConfig.getAccountId());
     if (startupConfig.enableIndexing || getBackgroundIndexing())
         enableIndexing = true;
 
@@ -1490,16 +1491,18 @@ void Global::stackDump(int max) {
 #endif // End windows check
 }
 
+void Global::setDebugLevelBySetting() {
+    settings->beginGroup("Debugging");
+    int level = settings->value("messageLevel", -1).toInt();
+    settings->endGroup();
+    setDebugLevel(level);
+}
 
 
 //************************************************
 //* Set the user debug level.
 //************************************************
-void Global::setDebugLevel() {
-    settings->beginGroup("Debugging");
-    int level = settings->value("messageLevel", -1).toInt();
-    settings->endGroup();
-
+void Global::setDebugLevel(int level) {
     // Setup the QLOG functions for debugging & messages
     QsLogging::Logger& logger = QsLogging::Logger::instance();
     if (level == QsLogging::TraceLevel)

--- a/global.h
+++ b/global.h
@@ -238,7 +238,8 @@ public:
     bool getClearSearchOnNotebook();
     bool getClearTagsOnSearch();
     bool getTagSelectionOr();
-    void setDebugLevel();
+    void setDebugLevel(int level);
+    void setDebugLevelBySetting();
     bool disableImageHighlight();
 
 

--- a/global.h
+++ b/global.h
@@ -200,7 +200,6 @@ public:
     bool autosetUsername();                                   // Should the username be set automatically?
     void setAutosetUsername(bool value);
     QString getUsername();                                    // pull username from the system.
-    QString getProgramDirPath();                              // Get the path the program is executing from
     QList< QPair<QString, QString> > passwordRemember;        // Cache of passwords
     QHash< QString, QPair <QString, QString> > passwordSafe;  // Saved passwords
     void appendFilter(FilterCriteria *criteria);
@@ -328,6 +327,7 @@ public:
     bool useLibTidy;
 
     ExitManager *exitManager;                                  // Utility to manage exit points.
+    QString getProgramDirPath() { return fileManager.getProgramDirPath(); }
 };
 
 bool caseInsensitiveLessThan(const QString &s1, const QString &s2);         // Helper function to sort values case-insensitive.

--- a/global.h
+++ b/global.h
@@ -327,7 +327,7 @@ public:
     bool useLibTidy;
 
     ExitManager *exitManager;                                  // Utility to manage exit points.
-    QString getProgramDirPath() { return fileManager.getProgramDirPath(); }
+    QString getProgramDataDir() { return fileManager.getProgramDataDir(); }
 };
 
 bool caseInsensitiveLessThan(const QString &s1, const QString &s2);         // Helper function to sort values case-insensitive.

--- a/gui/nbrowserwindow.cpp
+++ b/gui/nbrowserwindow.cpp
@@ -3556,7 +3556,7 @@ void NBrowserWindow::spellCheckPressed() {
                 QString newLang;
                 int idx = dialog.language->currentIndex();
                 newLang = dialog.language->itemText(idx);
-                hunspellInterface->initialize(global.fileManager.getProgramDirPath(""), global.fileManager.getSpellDirPathUser(),newLang);
+                hunspellInterface->initialize(global.fileManager.getProgramDirPath(), global.fileManager.getSpellDirPathUser(),newLang);
             }
             if (dialog.addToDictionaryPressed) {
                 hunspellInterface->addWord(global.fileManager.getSpellDirPathUser() +"user.lst", currentWord);
@@ -3805,8 +3805,8 @@ void NBrowserWindow::loadPlugins() {
     hunspellPluginAvailable = false;
 
     QStringList dirList;
-    dirList.append(global.fileManager.getProgramDirPath(""));
-    dirList.append(global.fileManager.getProgramDirPath("")+"/plugins");
+    dirList.append(global.fileManager.getProgramDirPath());
+    dirList.append(global.fileManager.getProgramDirPath()+"plugins");
     const QString prefixPath = QLibraryInfo::location(QLibraryInfo::PrefixPath);
     dirList.append(prefixPath + "/lib/nixnote2/");
 #ifndef Q_OS_MAC_OS
@@ -3844,7 +3844,7 @@ void NBrowserWindow::loadPlugins() {
                         global.settings->beginGroup("Locale");
                         QString dict = global.settings->value("translation").toString();
                         global.settings->endGroup();
-                        hunspellPluginAvailable = hunspellInterface->initialize(global.fileManager.getProgramDirPath(""),
+                        hunspellPluginAvailable = hunspellInterface->initialize(global.fileManager.getProgramDirPath(),
                             global.fileManager.getSpellDirPathUser(), errMsg, dict);
                         if (!hunspellPluginAvailable) {
                             QLOG_ERROR() << errMsg;

--- a/gui/nbrowserwindow.cpp
+++ b/gui/nbrowserwindow.cpp
@@ -3818,7 +3818,7 @@ void NBrowserWindow::loadPlugins() {
     }
     dirList.append("/usr/local/lib");
 #endif
-#if defined(Q_OS_MACOS) && defined(USE_QSP)
+#if defined(Q_OS_MACOS)
     // support installing additional plugins in the standard locations where they might be found
     dirList.append(QStandardPaths::locate(QStandardPaths::AppDataLocation, "plugins", QStandardPaths::LocateDirectory));
 #endif

--- a/gui/nbrowserwindow.cpp
+++ b/gui/nbrowserwindow.cpp
@@ -3556,7 +3556,7 @@ void NBrowserWindow::spellCheckPressed() {
                 QString newLang;
                 int idx = dialog.language->currentIndex();
                 newLang = dialog.language->itemText(idx);
-                hunspellInterface->initialize(global.fileManager.getProgramDirPath(), global.fileManager.getSpellDirPathUser(),newLang);
+                hunspellInterface->initialize(global.fileManager.getProgramDataDir(), global.fileManager.getSpellDirPathUser(),newLang);
             }
             if (dialog.addToDictionaryPressed) {
                 hunspellInterface->addWord(global.fileManager.getSpellDirPathUser() +"user.lst", currentWord);
@@ -3805,8 +3805,8 @@ void NBrowserWindow::loadPlugins() {
     hunspellPluginAvailable = false;
 
     QStringList dirList;
-    dirList.append(global.fileManager.getProgramDirPath());
-    dirList.append(global.fileManager.getProgramDirPath()+"plugins");
+    dirList.append(global.fileManager.getProgramDataDir());
+    dirList.append(global.fileManager.getProgramDataDir()+"plugins");
     const QString prefixPath = QLibraryInfo::location(QLibraryInfo::PrefixPath);
     dirList.append(prefixPath + "/lib/nixnote2/");
 #ifndef Q_OS_MAC_OS
@@ -3844,7 +3844,7 @@ void NBrowserWindow::loadPlugins() {
                         global.settings->beginGroup("Locale");
                         QString dict = global.settings->value("translation").toString();
                         global.settings->endGroup();
-                        hunspellPluginAvailable = hunspellInterface->initialize(global.fileManager.getProgramDirPath(),
+                        hunspellPluginAvailable = hunspellInterface->initialize(global.fileManager.getProgramDataDir(),
                             global.fileManager.getSpellDirPathUser(), errMsg, dict);
                         if (!hunspellPluginAvailable) {
                             QLOG_ERROR() << errMsg;

--- a/gui/nmainmenubar.cpp
+++ b/gui/nmainmenubar.cpp
@@ -605,13 +605,8 @@ void NMainMenuBar::setupShortcut(QAction *action, QString text) {
 
 
 void NMainMenuBar::openManual() {
-#ifndef _WIN32
     QDesktopServices::openUrl(QString("file://") +
-                             global.getProgramDirPath()+"/help/UserDocumentation.pdf");
-#else
-    QDesktopServices::openUrl(QString("file:///") +
-                             global.getProgramDirPath().replace("\\","/")+"/help/UserDocumentation.pdf");
-#endif
+                             global.getProgramDirPath()+"help/UserDocumentation.pdf");
 }
 
 

--- a/gui/nmainmenubar.cpp
+++ b/gui/nmainmenubar.cpp
@@ -606,7 +606,7 @@ void NMainMenuBar::setupShortcut(QAction *action, QString text) {
 
 void NMainMenuBar::openManual() {
     QDesktopServices::openUrl(QString("file://") +
-                             global.getProgramDirPath()+"help/UserDocumentation.pdf");
+                             global.getProgramDataDir()+"help/UserDocumentation.pdf");
 }
 
 

--- a/gui/shortcutkeys.cpp
+++ b/gui/shortcutkeys.cpp
@@ -204,8 +204,8 @@ ShortcutKeys::ShortcutKeys(QObject *parent) :
 
     loadkey(QString("Insert_DateTime"), Insert_DateTime);
 
-    QString userFileName = global.fileManager.getConfigDir() + QString("shortcuts.txt");
-    QString systemFileName = global.fileManager.getProgramDataDir() + QString("shortcuts.txt");
+    QString userFileName = global.fileManager.getConfigDir() + QString("shortcuts.txt"); // user shortcuts
+    QString systemFileName = global.fileManager.getProgramDataDir() + QString("shortcuts.txt"); // system shortcuts
 #ifdef _WIN32
     userFileName = userFileName.replace("\\","/");
     systemFileName = systemFileName.replace("\\","/");

--- a/gui/shortcutkeys.cpp
+++ b/gui/shortcutkeys.cpp
@@ -204,8 +204,8 @@ ShortcutKeys::ShortcutKeys(QObject *parent) :
 
     loadkey(QString("Insert_DateTime"), Insert_DateTime);
 
-    QString userFileName = global.fileManager.getHomeDirPath("") + QString("shortcuts.txt");
-    QString systemFileName = global.fileManager.getProgramDirPath("") + QString("shortcuts.txt");
+    QString userFileName = global.fileManager.getHomeDirPath() + QString("shortcuts.txt");
+    QString systemFileName = global.fileManager.getProgramDirPath() + QString("shortcuts.txt");
 #ifdef _WIN32
     userFileName = userFileName.replace("\\","/");
     systemFileName = systemFileName.replace("\\","/");

--- a/gui/shortcutkeys.cpp
+++ b/gui/shortcutkeys.cpp
@@ -243,7 +243,7 @@ void ShortcutKeys::loadCustomKeys(QString fileName) {
         }
         file.close();
     } else {
-        qDebug() << Q_FUNC_INFO << "Unable to open" << fileName << "for reading or file does not exist.";
+        QLOG_TRACE() << "Unable to open" << fileName << "for reading or file does not exist.";
     }
 }
 

--- a/gui/shortcutkeys.cpp
+++ b/gui/shortcutkeys.cpp
@@ -204,8 +204,8 @@ ShortcutKeys::ShortcutKeys(QObject *parent) :
 
     loadkey(QString("Insert_DateTime"), Insert_DateTime);
 
-    QString userFileName = global.fileManager.getHomeDirPath() + QString("shortcuts.txt");
-    QString systemFileName = global.fileManager.getProgramDirPath() + QString("shortcuts.txt");
+    QString userFileName = global.fileManager.getConfigDir() + QString("shortcuts.txt");
+    QString systemFileName = global.fileManager.getProgramDataDir() + QString("shortcuts.txt");
 #ifdef _WIN32
     userFileName = userFileName.replace("\\","/");
     systemFileName = systemFileName.replace("\\","/");

--- a/main.cpp
+++ b/main.cpp
@@ -128,6 +128,9 @@ int main(int argc, char *argv[])
     if (retval != 0)
         return retval;
 
+    // Show Qt version.  This is useful for debugging
+    QLOG_DEBUG() << "Built on " << __DATE__ << " at " << __TIME__;
+    QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
 
 
     // Setup the application. If we have a GUI, then we use Application.
@@ -187,13 +190,6 @@ int main(int argc, char *argv[])
     QsLogging::DestinationPtr fileDestination(
                  QsLogging::DestinationFactory::MakeFileDestination(logPath) ) ;
     logger.addDestination(fileDestination.get());
-
-
-    // Show Qt version.  This is useful for debugging
-    QLOG_DEBUG() << "programDir: " << global.fileManager.getProgramDataDir();
-    QLOG_DEBUG() << "Built on " << __DATE__ << " at " << __TIME__;
-    QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
-
 
 
     // Create a shared memory region.  We use this to communicate

--- a/main.cpp
+++ b/main.cpp
@@ -129,9 +129,10 @@ int main(int argc, char *argv[])
         return retval;
 
     // Show Qt version.  This is useful for debugging
-    QLOG_DEBUG() << "Built on " << __DATE__ << " at " << __TIME__;
-    QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
-
+    // initial log level is INFO - so this will be SHOWN per default
+    QLOG_INFO() << "Nixnote2 - build (" << __DATE__ << " at " << __TIME__
+                << ", with Qt" << QT_VERSION_STR << "running on" << qVersion() << ")";
+    QLOG_INFO() << "To get more detailed startup logging use --logLevel=1";
 
     // Setup the application. If we have a GUI, then we use Application.
     // If we don't, then we just use a derivative of QCoreApplication

--- a/main.cpp
+++ b/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
 
 
     // Show Qt version.  This is useful for debugging
-    QLOG_DEBUG() << "programDir: " << global.fileManager.getProgramDirPath();
+    QLOG_DEBUG() << "programDir: " << global.fileManager.getProgramDataDir();
     QLOG_DEBUG() << "Built on " << __DATE__ << " at " << __TIME__;
     QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
 

--- a/main.cpp
+++ b/main.cpp
@@ -141,10 +141,9 @@ int main(int argc, char *argv[])
     }
     global.application = a;
 
-    //startupConfig.programDirPath = global.getProgramDirPath() + QDir().separator();
     startupConfig.name = "NixNote";
     global.setup(startupConfig, guiAvailable);
-//    global.syncAndExit=startupConfig.syncAndExit;
+    //    global.syncAndExit=startupConfig.syncAndExit;
 
     // We were passed a SQL command
     if (startupConfig.sqlExec) {
@@ -191,7 +190,7 @@ int main(int argc, char *argv[])
 
 
     // Show Qt version.  This is useful for debugging
-    QLOG_DEBUG() << "Program Home: " << global.fileManager.getProgramDirPath("");
+    QLOG_DEBUG() << "programDir: " << global.fileManager.getProgramDirPath();
     QLOG_DEBUG() << "Built on " << __DATE__ << " at " << __TIME__;
     QLOG_DEBUG() << "Built with Qt" << QT_VERSION_STR << "running on" << qVersion();
 

--- a/main.cpp
+++ b/main.cpp
@@ -103,6 +103,17 @@ int main(int argc, char *argv[])
     w = NULL;
     bool guiAvailable = true;
 
+    // Setup the QLOG functions for debugging & messages
+    // we need to do it at very beginning, else we lose the startup messages
+    QsLogging::Logger& logger = QsLogging::Logger::instance();
+    // at very beginning we starting with info level to get basic startup info
+    // log level is later adjusted by settings
+    logger.setLoggingLevel(QsLogging::InfoLevel);
+
+    QsLogging::DestinationPtr debugDestination(
+        QsLogging::DestinationFactory::MakeDebugOutputDestination() );
+    logger.addDestination(debugDestination.get());
+
 // Windows Check
 #ifndef _WIN32
     signal(SIGSEGV, fault_handler);   // install our handler
@@ -130,15 +141,7 @@ int main(int argc, char *argv[])
     }
     global.application = a;
 
-    // Setup the QLOG functions for debugging & messages
-    QsLogging::Logger& logger = QsLogging::Logger::instance();
-    logger.setLoggingLevel(QsLogging::TraceLevel);
-
-    QsLogging::DestinationPtr debugDestination(
-                QsLogging::DestinationFactory::MakeDebugOutputDestination() );
-    logger.addDestination(debugDestination.get());
-
-    startupConfig.programDirPath = global.getProgramDirPath() + QDir().separator();
+    //startupConfig.programDirPath = global.getProgramDirPath() + QDir().separator();
     startupConfig.name = "NixNote";
     global.setup(startupConfig, guiAvailable);
 //    global.syncAndExit=startupConfig.syncAndExit;

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -124,7 +124,7 @@ NixNote::NixNote(QWidget *parent) : QMainWindow(parent)
 #if QT_VERSION < 0x050000
     QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
 #endif
-    global.setDebugLevel();
+    global.setDebugLevelBySetting();
 
     // Load any plugins
     this->loadPlugins();
@@ -2997,7 +2997,7 @@ void NixNote::openPreferences() {
 //        QApplication::instance()->installTranslator(nixnoteTranslator);
 
     }
-    global.setDebugLevel();
+    global.setDebugLevelBySetting();
 }
 
 

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -3889,8 +3889,8 @@ void NixNote::loadPlugins() {
     webcamPluginAvailable = false;
 
     QStringList dirList;
-    dirList.append(global.fileManager.getProgramDirPath());
-    dirList.append(global.fileManager.getProgramDirPath()+"plugins");
+    dirList.append(global.fileManager.getProgramDataDir());
+    dirList.append(global.fileManager.getProgramDataDir()+"plugins");
     const QString prefixPath = QLibraryInfo::location(QLibraryInfo::PrefixPath);
     dirList.append(prefixPath + "/lib/nixnote2/");
 #ifndef Q_OS_MAC_OS

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -124,8 +124,6 @@ NixNote::NixNote(QWidget *parent) : QMainWindow(parent)
 #if QT_VERSION < 0x050000
     QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
 #endif
-    global.setDebugLevelBySetting();
-
     // Load any plugins
     this->loadPlugins();
 

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -3902,7 +3902,7 @@ void NixNote::loadPlugins() {
     }
     dirList.append("/usr/local/lib");
 #endif
-#if defined(Q_OS_MACOS) && defined(USE_QSP)
+#if defined(Q_OS_MACOS)
     // support installing additional plugins in the standard locations where they might be found
     dirList.append(QStandardPaths::locate(QStandardPaths::AppDataLocation, "plugins", QStandardPaths::LocateDirectory));
 #endif

--- a/nixnote.cpp
+++ b/nixnote.cpp
@@ -3889,8 +3889,8 @@ void NixNote::loadPlugins() {
     webcamPluginAvailable = false;
 
     QStringList dirList;
-    dirList.append(global.fileManager.getProgramDirPath(""));
-    dirList.append(global.fileManager.getProgramDirPath("")+"/plugins");
+    dirList.append(global.fileManager.getProgramDirPath());
+    dirList.append(global.fileManager.getProgramDirPath()+"plugins");
     const QString prefixPath = QLibraryInfo::location(QLibraryInfo::PrefixPath);
     dirList.append(prefixPath + "/lib/nixnote2/");
 #ifndef Q_OS_MAC_OS

--- a/settings/accountsmanager.cpp
+++ b/settings/accountsmanager.cpp
@@ -30,11 +30,7 @@ AccountsManager::AccountsManager(int id, QObject *parent) :
     QObject(parent)
 {
     currentId = id;
-#ifdef USE_QSP
-    configFile = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/accounts.conf";
-#else
     configFile = global.fileManager.getConfigDir()+"accounts.conf";
-#endif
     if (!QFile(configFile).exists()) {
         QFile xmlFile(configFile);
         xmlFile.open(QIODevice::WriteOnly | QIODevice::Text);

--- a/settings/accountsmanager.cpp
+++ b/settings/accountsmanager.cpp
@@ -33,7 +33,7 @@ AccountsManager::AccountsManager(int id, QObject *parent) :
 #ifdef USE_QSP
     configFile = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/accounts.conf";
 #else
-    configFile = global.fileManager.getHomeDirPath()+"accounts.conf";
+    configFile = global.fileManager.getConfigDir()+"accounts.conf";
 #endif
     if (!QFile(configFile).exists()) {
         QFile xmlFile(configFile);

--- a/settings/accountsmanager.cpp
+++ b/settings/accountsmanager.cpp
@@ -33,7 +33,7 @@ AccountsManager::AccountsManager(int id, QObject *parent) :
 #ifdef USE_QSP
     configFile = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/accounts.conf";
 #else
-    configFile = global.fileManager.getHomeDirPath("")+"accounts.conf";
+    configFile = global.fileManager.getHomeDirPath()+"accounts.conf";
 #endif
     if (!QFile(configFile).exists()) {
         QFile xmlFile(configFile);

--- a/settings/colorsettings.cpp
+++ b/settings/colorsettings.cpp
@@ -46,8 +46,9 @@ ColorSettings::ColorSettings(QObject *parent) :
     colors.insert(tr("Grey"), "grey");
     colors.insert(tr("Powder Blue"), "powderblue");
 
-    QString userFile = global.fileManager.getHomeDirPath("") + QString("colors.txt");
-    QString globalFile = global.fileManager.getProgramDirPath("") +QString("colors.txt");
+    QString userFile = global.fileManager.getHomeDirPath() + QString("colors.txt");
+    QString globalFile = global.fileManager.getProgramDirPath() +QString("colors.txt");
+
     QSettings globalSettings(globalFile, QSettings::IniFormat);
     QSettings userSettings(userFile, QSettings::IniFormat);
 

--- a/settings/colorsettings.cpp
+++ b/settings/colorsettings.cpp
@@ -46,8 +46,8 @@ ColorSettings::ColorSettings(QObject *parent) :
     colors.insert(tr("Grey"), "grey");
     colors.insert(tr("Powder Blue"), "powderblue");
 
-    QString userFile = global.fileManager.getHomeDirPath() + QString("colors.txt");
-    QString globalFile = global.fileManager.getProgramDirPath() +QString("colors.txt");
+    QString userFile = global.fileManager.getConfigDir() + QString("colors.txt");
+    QString globalFile = global.fileManager.getProgramDataDir() +QString("colors.txt");
 
     QSettings globalSettings(globalFile, QSettings::IniFormat);
     QSettings userSettings(userFile, QSettings::IniFormat);

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -21,10 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "global.h"
 #include <iostream>
 #include <cstdlib>
-
-#ifdef USE_QSP
 #include <QLibraryInfo>
-#endif
 
 //*******************************************
 //* This class is used to find the location

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -83,10 +83,10 @@ void  FileManager::setup(QString startupConfigDir, QString startupUserDataDir, Q
         legacyConfigDir.setPath(legacyConfigDirPath);
         QLOG_DEBUG() << "FileManager::setup checking whenever legacy config dir exists: " << legacyConfigDirPath;
         if (legacyConfigDir.exists()) {
-            QLOG_DEBUG() << "FileManager::setup legacy config/data dir found. Reverting to that: "
-                         << legacyConfigDirPath;
-            this->configDir = legacyConfigDirPath;
-            this->userDataDir = legacyConfigDirPath;
+            this->configDir = slashTerminatePath(legacyConfigDirPath);
+            this->userDataDir = this->configDir;
+            QLOG_DEBUG() << "FileManager::setup legacy config/data dir found. falling back to that: "
+                         << this->configDir;
         }
     }
 
@@ -237,17 +237,18 @@ void FileManager::createDirOrCheckWriteable(QDir dir) {
 /* Check that an existing directory is readable.  */
 /**************************************************/
 void FileManager::checkExistingReadableDir(QDir dir) {
+    QString path = dir.path();
     // Windows Check
     #ifndef _WIN32
-    QLOG_DEBUG() << "Checking read access for directory " << dir;
+    QLOG_DEBUG() << "Checking read access for directory " << path;
     if (!dir.isReadable()) {
-            QLOG_FATAL() << "Directory '" + dir.path() + "' does not have read permission.  Aborting program.";
+            QLOG_FATAL() << "Directory '" + path + "' does not have read permission.  Aborting program.";
             exit(16);
     }
     #endif  // end windows check
 
     if (!dir.exists()) {
-         QLOG_FATAL() << "Directory '" + dir.path() + "' does not exist.  Aborting program";
+         QLOG_FATAL() << "Directory '" + path + "' does not exist.  Aborting program";
          exit(16);
     }
 }
@@ -269,9 +270,10 @@ bool isWriteable(QDir dir) {
 /* Check that an existing directory is writable.  */
 /**************************************************/
 void FileManager::checkExistingWriteableDir(QDir dir) {
-    QLOG_DEBUG() << "Checking write access for directory " << dir;
+    QString path(dir.path());
+    QLOG_DEBUG() << "Checking write access for directory " << path;
     if (!isWriteable(dir)) {
-        QLOG_FATAL() << "Directory '" + dir.path() + "' does not have read permission.  Aborting program.";
+        QLOG_FATAL() << "Directory '" + path + "' does not have read permission.  Aborting program.";
         exit(16);
     }
 }

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -125,7 +125,7 @@ void  FileManager::setup(QString startupConfigDir, QString startupUserDataDir, Q
     javaDirPath = slashTerminatePath(javaDir.path());
 
     spellDirUser.setPath(programDataDir + "spell");
-    createDirOrCheckWriteable(spellDirUser);
+    checkExistingReadableDir(spellDirUser);
     spellDirPathUser = slashTerminatePath(spellDirUser.path());
 
     translateDir.setPath(programDataDir + "translations");

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -68,31 +68,32 @@ void FileManager::setup(QString startupConfigDirPath, QString startupProgramDirP
     QLOG_DEBUG() << "FileManager::setup startupConfigDirPath: " << startupConfigDirPath << ", startupProgramDirPath: "
                  << startupProgramDirPath;
 
-    this->programDirPath = startupProgramDirPath;
-    this->configDirPath = startupConfigDirPath;
+    this->programDataDir = startupProgramDirPath;
+    this->configDir = startupConfigDirPath;
 
-    if (this->configDirPath.isEmpty()) {
+    if (this->configDir.isEmpty()) {
         // default config path
-        this->configDirPath = slashTerminatePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+        this->configDir = slashTerminatePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 
         // TODO
-        // in order to not break things for existing user, check whenewer this -> configDirPath exists
+        // in order to not break things for existing user, check whenewer this -> configDir exists
         // if it doesn't exist & the OLD path exists - take old path
-        // OLD: this -> configDirPath = slashTerminatePath(QDir().homePath() + QString("/.nixnote"));
+        // OLD: this -> configDir = slashTerminatePath(QDir().homePath() + QString("/.nixnote"));
     }
-    createDirOrCheckWriteable(configDirPath);
+    createDirOrCheckWriteable(configDir);
 
-    if (this->programDirPath.isEmpty()) {
+    if (this->programDataDir.isEmpty()) {
         // default config path
-        this->programDirPath = slashTerminatePath(getDefaultProgramDirPath());
+        this->programDataDir = slashTerminatePath(getDefaultProgramDirPath());
     }
 
-    QLOG_DEBUG() << "FileManager::setup configDirPath: " << this->configDirPath << ", programDirPath: "
-                 << this->programDirPath;
+    QLOG_DEBUG() << "FileManager::setup "
+                 << "configDir: " << this->configDirPath
+                 << ", programDataDir: " << this->programDataDir;
 
-    #ifdef Q_OS_MACOS
+#ifdef Q_OS_MACOS
         // get the resources from the app bundle
-        this->dataDirPath = programDirPath;
+        this->dataDirPath = programDataDir;
     #else
         this->dataDirPath = QLibraryInfo::location(QLibraryInfo::PrefixPath) + "/share/nixnote2/";
     #endif
@@ -249,10 +250,10 @@ void FileManager::checkExistingWriteableDir(QDir dir) {
     this->checkExistingReadableDir(dir);
 }
 
-QString FileManager::getProgramDirPath() {
-    return programDirPath;
+QString FileManager::getProgramDataDir() {
+    return programDataDir;
 }
-QString FileManager::getHomeDirPath() {
+QString FileManager::getConfigDir() {
     return configDirPath;
 }
 QDir FileManager::getSpellDirFileUser(QString relativePath) {

--- a/settings/filemanager.cpp
+++ b/settings/filemanager.cpp
@@ -58,110 +58,106 @@ QString getDefaultProgramDirPath() {
 }
 
 
-void FileManager::setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId) {
-    if (!startupConfigDirPath.isEmpty()) {
-        startupConfigDirPath = slashTerminatePath(startupConfigDirPath);
+void FileManager::setup(QString startupConfigDir, QString startupProgramDataDir, int accountId) {
+    if (!startupConfigDir.isEmpty()) {
+        startupConfigDir = slashTerminatePath(startupConfigDir);
     }
-    if (!startupProgramDirPath.isEmpty()) {
-        startupProgramDirPath = slashTerminatePath(startupProgramDirPath);
+    if (!startupProgramDataDir.isEmpty()) {
+        startupProgramDataDir = slashTerminatePath(startupProgramDataDir);
     }
-    QLOG_DEBUG() << "FileManager::setup startupConfigDirPath: " << startupConfigDirPath << ", startupProgramDirPath: "
-                 << startupProgramDirPath;
+    QLOG_DEBUG() << "FileManager::setup"
+                 << " startupConfigDirPath: " << startupConfigDir
+                 << ", startupProgramDirPath: " << startupProgramDataDir;
 
-    this->programDataDir = startupProgramDirPath;
-    this->configDir = startupConfigDirPath;
+    this->programDataDir = startupProgramDataDir;
+    this->configDir = startupConfigDir;
 
     if (this->configDir.isEmpty()) {
         // default config path
         this->configDir = slashTerminatePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 
         // TODO
-        // in order to not break things for existing user, check whenewer this -> configDir exists
+        // in order to not break things for existing user, check whenever this -> configDir exists
         // if it doesn't exist & the OLD path exists - take old path
         // OLD: this -> configDir = slashTerminatePath(QDir().homePath() + QString("/.nixnote"));
     }
     createDirOrCheckWriteable(configDir);
 
+    // in case nothing was given on command line, set to default
     if (this->programDataDir.isEmpty()) {
         // default config path
         this->programDataDir = slashTerminatePath(getDefaultProgramDirPath());
     }
 
     QLOG_DEBUG() << "FileManager::setup "
-                 << "configDir: " << this->configDirPath
+                 << "configDir: " << this->configDir
                  << ", programDataDir: " << this->programDataDir;
 
-#ifdef Q_OS_MACOS
-        // get the resources from the app bundle
-        this->dataDirPath = programDataDir;
-    #else
-        this->dataDirPath = QLibraryInfo::location(QLibraryInfo::PrefixPath) + "/share/nixnote2/";
-    #endif
-
-    const QString userDataDir(slashTerminatePath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)));
-    QLOG_DEBUG() << "FileManager::setup dataDirPath: " << this->dataDirPath;
+    // TODO need first check if old data is present !!
+    this->userDataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    QLOG_DEBUG() << "FileManager::setup userDataDir: " << this->userDataDir;
 
     // Read only files that everyone uses
-    imagesDir.setPath(dataDirPath+"images");
+    imagesDir.setPath(programDataDir + "images");
     checkExistingReadableDir(imagesDir);
     imagesDirPath = slashTerminatePath(imagesDir.path());
 
-    javaDir.setPath(dataDirPath+"java");
+    javaDir.setPath(programDataDir + "java");
     checkExistingReadableDir(javaDir);
     javaDirPath = slashTerminatePath(javaDir.path());
 
-    spellDirUser.setPath(userDataDir+"spell");
+    spellDirUser.setPath(programDataDir + "spell");
     createDirOrCheckWriteable(spellDirUser);
     spellDirPathUser = slashTerminatePath(spellDirUser.path());
 
-    translateDir.setPath(dataDirPath+"translations");
+    translateDir.setPath(programDataDir + "translations");
     checkExistingReadableDir(translateDir);
-    translateDirPath= slashTerminatePath(translateDir.path());
+    translateDirPath = slashTerminatePath(translateDir.path());
 
-    qssDir.setPath(dataDirPath+"qss");
+    qssDir.setPath(programDataDir + "qss");
     checkExistingReadableDir(qssDir);
     qssDirPath = slashTerminatePath(qssDir.path());
 
     // Read/write directories that only we use
 
-    QString settingsFile = configDirPath + "nixnote.conf";
+    QString settingsFile = configDir + "nixnote.conf";
     QLOG_DEBUG() << "FileManager::setup settingsFile: " << settingsFile;
     QSettings globalSettings(settingsFile, QSettings::IniFormat);
 
-    if (accountId <=0) {
+    if (accountId <= 0) {
         globalSettings.beginGroup("SaveState");
         int accountIdFromSettings = globalSettings.value("lastAccessedAccount", 1).toInt();
         globalSettings.endGroup();
         accountId = accountIdFromSettings;
     }
 
-    qssDirUser.setPath(userDataDir+"qss");
+    qssDirUser.setPath(configDir + "qss");
     createDirOrCheckWriteable(qssDirUser);
     qssDirPathUser = slashTerminatePath(qssDirUser.path());
 
-    logsDir.setPath(userDataDir+"logs-" +QString::number(accountId));
+    logsDir.setPath(userDataDir + "logs-" + QString::number(accountId));
     createDirOrCheckWriteable(logsDir);
     logsDirPath = slashTerminatePath(logsDir.path());
 
-    tmpDir.setPath(userDataDir+"tmp-" +QString::number(accountId));
+    tmpDir.setPath(userDataDir + "tmp-" + QString::number(accountId));
     createDirOrCheckWriteable(tmpDir);
     tmpDirPath = slashTerminatePath(tmpDir.path());
 
-    QString dbPath = userDataDir+"db-" +QString::number(accountId);
+    QString dbPath = userDataDir + "db-" + QString::number(accountId);
     dbDir.setPath(dbPath);
 
     createDirOrCheckWriteable(dbDir);
     dbDirPath = slashTerminatePath(dbDir.path());
 
-    dbaDir.setPath(dbDirPath+"dba");
+    dbaDir.setPath(dbDirPath + "dba");
     createDirOrCheckWriteable(dbaDir);
     dbaDirPath = slashTerminatePath(dbaDir.path());
 
-    dbiDir.setPath(dbDirPath+"dbi");
+    dbiDir.setPath(dbDirPath + "dbi");
     createDirOrCheckWriteable(dbiDir);
     dbiDirPath = slashTerminatePath(dbiDir.path());
 
-    thumbnailDir.setPath(dbDirPath+"tdba");
+    thumbnailDir.setPath(dbDirPath + "tdba");
     createDirOrCheckWriteable(thumbnailDir);
     thumbnailDirPath = slashTerminatePath(thumbnailDir.path());
 }
@@ -250,12 +246,6 @@ void FileManager::checkExistingWriteableDir(QDir dir) {
     this->checkExistingReadableDir(dir);
 }
 
-QString FileManager::getProgramDataDir() {
-    return programDataDir;
-}
-QString FileManager::getConfigDir() {
-    return configDirPath;
-}
 QDir FileManager::getSpellDirFileUser(QString relativePath) {
     return spellDirPathUser + toPlatformPathSeparator(relativePath);
 }

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -45,8 +45,8 @@ class FileManager : public QObject
 {
     Q_OBJECT
 private:
-    QString programDirPath;
-    QString configDirPath;
+    QString programDataDir;
+    QString configDir;
     QString dataDirPath;
 
     QString dbDirPath;
@@ -96,8 +96,10 @@ public:
     FileManager();
     void setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId);
 
-    QString getProgramDirPath();
-    QString getHomeDirPath();
+    // new global file path interface -------
+    QString getProgramDataDir();
+    QString getConfigDir();
+    // new global file path interface -------
 
     QString getSpellDirPath();
     QDir getSpellDirFileUser(QString relativePath);

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -46,12 +46,9 @@ class FileManager : public QObject
     Q_OBJECT
 private:
     QString programDirPath;
-    QDir programDir;
+    QString configDirPath;
 
-    QString  configDirPath;
-    QDir configDir;
-
-    QString  dataDirPath;
+    QString dataDirPath;
     QDir dataDir;
 
     QString dbDirPath;
@@ -102,7 +99,6 @@ public:
     void setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId);
 
     QString getProgramDirPath(QString relativePath);
-
     QString getHomeDirPath(QString relativePath);
 
     QString getSpellDirPath();

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -47,9 +47,7 @@ class FileManager : public QObject
 private:
     QString programDirPath;
     QString configDirPath;
-
     QString dataDirPath;
-    QDir dataDir;
 
     QString dbDirPath;
     QDir dbDir;
@@ -98,8 +96,8 @@ public:
     FileManager();
     void setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId);
 
-    QString getProgramDirPath(QString relativePath);
-    QString getHomeDirPath(QString relativePath);
+    QString getProgramDirPath();
+    QString getHomeDirPath();
 
     QString getSpellDirPath();
     QDir getSpellDirFileUser(QString relativePath);

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -95,7 +95,7 @@ private:
 
 public:
     FileManager();
-    void setup(QString startupConfigDir, QString startupProgramDataDir, int accountId);
+    void setup(QString startupConfigDir, QString startupUserDataDir, QString startupProgramDataDir, int accountId);
 
     // new global file path interface ------- -----------------------------------------------------------
     // where "nixnote.conf" is stored (but NOT database, logs etc.)

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -44,16 +44,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 class FileManager : public QObject
 {
     Q_OBJECT
-
 private:
-
-    //QRegExp ALL_PATH_SEPARATORS_REGEX = "[/\\\\]";
-
     QString programDirPath;
     QDir programDir;
 
-    QString  homeDirPath;
-    QDir homeDir;
+    QString  configDirPath;
+    QDir configDir;
 
     QString  dataDirPath;
     QDir dataDir;
@@ -69,9 +65,6 @@ private:
 
     QString javaDirPath;
     QDir javaDir;
-
-//    QString spellDirPath;
-//    QDir spellDir;
 
     QString spellDirPathUser;
     QDir spellDirUser;
@@ -94,8 +87,6 @@ private:
     QString thumbnailDirPath;
     QDir thumbnailDir;
 
-    //QDir xmlDir;
-
     QString translateDirPath;
     QDir translateDir;
 
@@ -106,16 +97,14 @@ private:
     void checkExistingReadableDir(QDir dir);
     void checkExistingWriteableDir(QDir dir);
 
-
 public:
     FileManager();
-    void setup(QString homeDirPath, QString programDirPath, int id);
-    QDir getProgramDirFile(QString relativePath);
+    void setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId);
+
     QString getProgramDirPath(QString relativePath);
-    QDir getHomeDirFile(QString relativePath);
+
     QString getHomeDirPath(QString relativePath);
-//    QString getSpellDirPath(QString relativePath);
-//    QDir getSpellDirFile(QString relativePath);
+
     QString getSpellDirPath();
     QDir getSpellDirFileUser(QString relativePath);
     QString getSpellDirPathUser();
@@ -140,15 +129,8 @@ public:
     QString getTmpDirPath();
     QString getTmpDirPath(QString relativePath);
     QString getTmpDirPathSpecialChar(QString relativePath);
-    //QDir getXMLDirFile(QString relativePath);
     QString getTranslateFilePath(QString relativePath);
     void purgeResDirectory(bool exitOnFail);
-
-
-signals:
-
-public slots:
-
 };
 
 #endif // FILEMANAGER_H

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -26,16 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <QFile>
 #include <QDir>
 #include <exception>
-
-// Under Qt5, use QStandardPaths except when told not to, or on MS Windows
-// (the latter choice may be unwise but I cannot test).
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && !defined(DONT_USE_QSTANDARDPATHS) && !defined(_WIN32)
-#define USE_QSP
-#endif
-
-#ifdef USE_QSP
 #include <QStandardPaths>
-#endif
 
 //************************************************
 //* This class is used to retrieve the

--- a/settings/filemanager.h
+++ b/settings/filemanager.h
@@ -45,9 +45,10 @@ class FileManager : public QObject
 {
     Q_OBJECT
 private:
-    QString programDataDir;
+    // see: getter method for description
     QString configDir;
-    QString dataDirPath;
+    QString programDataDir;
+    QString userDataDir;
 
     QString dbDirPath;
     QDir dbDir;
@@ -94,12 +95,19 @@ private:
 
 public:
     FileManager();
-    void setup(QString startupConfigDirPath, QString startupProgramDirPath, int accountId);
+    void setup(QString startupConfigDir, QString startupProgramDataDir, int accountId);
 
-    // new global file path interface -------
-    QString getProgramDataDir();
-    QString getConfigDir();
-    // new global file path interface -------
+    // new global file path interface ------- -----------------------------------------------------------
+    // where "nixnote.conf" is stored (but NOT database, logs etc.)
+    QString getConfigDir() { return configDir; };
+
+    // where additional resources are stored e.g. "help/*", "images/*" etc.
+    QString getProgramDataDir() { return programDataDir; };
+
+    // where user data dir is stored (e.g. database, logs etc.)
+    QString getUserDataDir() { return userDataDir; };
+    // new global file path interface ------- -----------------------------------------------------------
+
 
     QString getSpellDirPath();
     QDir getSpellDirFileUser(QString relativePath);

--- a/settings/startupconfig.cpp
+++ b/settings/startupconfig.cpp
@@ -33,7 +33,7 @@ StartupConfig::StartupConfig()
     // we first allow command line override and set-up final directory later in global.setup()
     configDir = QString("");
     programDataDir = QString("");
-
+    this->logLevel = -1; // default: not set by command line
     this->forceNoStartMinimized = false;
     this->startupNewNote = false;
     this->sqlExec = false;
@@ -44,6 +44,7 @@ StartupConfig::StartupConfig()
     this->forceSystemTrayAvailable=false;
     this->disableEditing = false;
     this->accountId=-1;
+
     command = new QBitArray(STARTUP_OPTION_COUNT);
     command->fill(false);
     newNote = NULL;
@@ -242,9 +243,10 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
         }
         if (parm.startsWith("--logLevel=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1); // 2nd part
-            int level= parm.toInt();
+            int level = parm.toInt();
+            QLOG_INFO() << "Changed logLevel via command line option to " << level;
             global.setDebugLevel(level);
-            QLOG_DEBUG() << "Changed logLevel via command line option to " << level;
+            this->logLevel = level;
         }
         if (parm.startsWith("--accountId=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);

--- a/settings/startupconfig.cpp
+++ b/settings/startupconfig.cpp
@@ -32,7 +32,7 @@ StartupConfig::StartupConfig()
 {
     // we first allow command line override and set-up final directory later in global.setup()
     configDir = QString("");
-    programDir = QString("");
+    programDataDir = QString("");
 
     this->forceNoStartMinimized = false;
     this->startupNewNote = false;
@@ -71,7 +71,12 @@ void StartupConfig::printHelp() {
                    +QString("          --logLevel=<level>           Set initial logging level (0=trace,1=debug,2=info,3=error,..\n")
                    +QString("                                       This is ONLY valid at program startup until settings are read.\n")
                    +QString("          --accountId=<id>             Start with specified user account.\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
+
+                   // see FileManager.getConfigDir() for more info
+                   +QString("          --configDir=<dir>            Directory containing config files.\n")
+                   +QString("          --programDataDir=<dir>       Directory containing deployed fixed program data (like images).\n")
+                   +QString("          --userDataDir=<dir>          Directory containing database, logs etc..\n")
+
                    +QString("          --dontStartMinimized         Override option to start minimized.\n")
                    +QString("          --disableEditing             Disable note editing\n")
                    +QString("          --enableIndexing             Enable background Indexing (can cause problems)\n")
@@ -85,8 +90,6 @@ void StartupConfig::printHelp() {
                    +QString("  show_window                          If running, ask NixNote to show the main window.\n")
                    +QString("  query <options>                      If running, search NixNote and display the results.\n")
                    +QString("     query options:\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("          --search=\"search string\"     Search string.\n\n")
                    +QString("          --delimiter=\"character\"      Character to place between fields.  Defaults to |.\n")
                    +QString("          --noHeaders                  Do not show column headings.")
@@ -121,8 +124,6 @@ void StartupConfig::printHelp() {
                    +QString("          --reminder=\"<datetime>\"  Reminder date & time in yyyy-MM-ddTHH:mm:ss.zzzZ format.\n")
                    +QString("          --noteText=\"<text>\"          Text of the note.  If not provided input\n")
                    +QString("                                       is read from stdin.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  appendNote <options>                 Append to an existing note.\n")
                    +QString("     appendNote options:\n")
                    +QString("          --id=\"<title>\"               ID of note to append.\n")
@@ -132,8 +133,6 @@ void StartupConfig::printHelp() {
                    +QString("                                       Defaults to %%.\n")
                    +QString("          --noteText=\"<text>\"          Text of the note.  If not provided input\n")
                    +QString("                                       is read from stdin.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  alterNote <options>                  Change a notes't notebook or tags.\n")
                    +QString("     alterNote options:\n")
                    +QString("          --id=\"<note_ids>\"            Space separated list of note IDs to extract.\n")
@@ -146,18 +145,12 @@ void StartupConfig::printHelp() {
                    +QString("          --reminderComplete           Set the reminder as complete.\n")
                    +QString("                                       yyyy-MM-ddTHH:mm:ss.zzzZ format or the literal 'now' to default\n")
                    +QString("                                       to the current date & time.")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  readNote <options>                   Read the text contents of a note.\n")
                    +QString("          --id=\"<note_id>\"             ID of the note to read.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  deleteNote <options>                 Move a note to the trash via the command line.\n")
                    +QString("     deleteNote options:\n")
                    +QString("          --id=\"<note_id>\"             ID of the note to delete.\n")
                    +QString("          --noVerify                   Do not prompt for verification.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  emailNote <options>                  Move a note to the trash via the command line.\n")
                    +QString("     emailNote options:\n")
                    +QString("          --id=\"<note_id>\"             ID of the note to email.\n")
@@ -167,13 +160,9 @@ void StartupConfig::printHelp() {
                    +QString("          --bcc=\"<address list>\"       List of recipients to blind carbon copy.\n")
                    +QString("          --note=\"<note>\"              Additional comments.\n")
                    +QString("          --ccSelf                     Send a copy to yourself.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  backup <options>                     Backup the NixNote database.\n")
                    +QString("     backup options:\n")
                    +QString("          --output=<filename>          Output filename.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  export <options>                     Export notes from NixNote.\n")
                    +QString("     export options:\n")
                    +QString("          --id=\"<note_ids>\"            Space separated list of note IDs to extract.\n")
@@ -181,23 +170,15 @@ void StartupConfig::printHelp() {
                    +QString("          --output=\"filename\"        Output file name.\n")
                    +QString("          --deleteAfterExtract         Delete notes after the extract completes.\n")
                    +QString("          --noVerifyDelete             Don't verify deletions.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  import <options>                     Import notes from a NixNote extract (.nnex).\n")
                    +QString("     import options:\n")
                    +QString("          --input=\"filename\"         Input file name.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  closeNotebook <options>              Close a notebook.\n")
                    +QString("     closeNotebook options:\n")
                    +QString("          --notebook=\"notebook\"        Notebook name.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  openNotebook <options>               Open a closed a notebook.\n")
                    +QString("     openNotebook options:\n")
                    +QString("          --notebook=\"notebook\"        Notebook name.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  signalGui <options>                  Send command to a running NixNote.\n")
                    +QString("     signalGui options:\n")
                    +QString("          --show                       Show NixNote if hidden.\n")
@@ -210,10 +191,8 @@ void StartupConfig::printHelp() {
                    +QString("          --id=<id>                    Note Id to open.\n")
                    +QString("          --newNote                    Create a new note.\n")
                    +QString("          --newExternalNote            Create a new note in an external window.\n")
-                   +QString("          --accountId=<id>             Account number (defaults to last used account).\n\n")
-                   +QString("          --configDir=<dir>            Directory containing config & database.\n")
                    +QString("  Examples:\n\n")
-                   +QString("     To Start NixNote, do a sync, and then exit.\n")
+                   +QString("     To start NixNote, do a sync, and then exit.\n")
                    +QString("     nixnote2 start --syncAndExit\n\n")
                    +QString("     To start NixNote using a secondary account.\n")
                    +QString("     nixnote2 --accountId=2\n\n")
@@ -272,16 +251,25 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
             accountId = parm.toInt();
             QLOG_DEBUG() << "Set accountId via command line option to " + accountId;
         }
+
+        // directory overrides
         if (parm.startsWith("--configDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
             configDir = parm;
             QLOG_DEBUG() << "Set configDir via command line to " + configDir;
         }
-        if (parm.startsWith("--programDir=", Qt::CaseSensitive)) {
+        if (parm.startsWith("--programDataDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
-            programDir = parm;
-            QLOG_DEBUG() << "Set programDir via command line to " + programDir;
+            programDataDir = parm;
+            QLOG_DEBUG() << "Set programDataDir via command line to " + programDataDir;
         }
+        if (parm.startsWith("--userDataDir=", Qt::CaseSensitive)) {
+            parm = parm.section('=', 1, 1);
+            programDataDir = parm;
+            QLOG_DEBUG() << "Set userDataDir via command line to " + userDataDir;
+        }
+
+
         if (parm.startsWith("addNote")) {
             command->setBit(STARTUP_ADDNOTE,true);
             if (newNote == NULL)

--- a/settings/startupconfig.cpp
+++ b/settings/startupconfig.cpp
@@ -75,8 +75,10 @@ void StartupConfig::printHelp() {
 
                    // see FileManager.getConfigDir() for more info
                    +QString("          --configDir=<dir>            Directory containing config files.\n")
-                   +QString("          --programDataDir=<dir>       Directory containing deployed fixed program data (like images).\n")
                    +QString("          --userDataDir=<dir>          Directory containing database, logs etc..\n")
+                   +QString("                                       Warning: ff you set configDir, but don't set userDataDir; userDataDir defaults\n")
+                   +QString("                                       to configDir.\n")
+                   +QString("          --programDataDir=<dir>       Directory containing deployed fixed program data (like images).\n")
 
                    +QString("          --dontStartMinimized         Override option to start minimized.\n")
                    +QString("          --disableEditing             Disable note editing\n")
@@ -258,17 +260,17 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
         if (parm.startsWith("--configDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
             configDir = parm;
-            QLOG_DEBUG() << "Set configDir via command line to " + configDir;
+            QLOG_INFO() << "Set configDir via command line to " + configDir;
         }
         if (parm.startsWith("--programDataDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
             programDataDir = parm;
-            QLOG_DEBUG() << "Set programDataDir via command line to " + programDataDir;
+            QLOG_INFO() << "Set programDataDir via command line to " + programDataDir;
         }
         if (parm.startsWith("--userDataDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
-            programDataDir = parm;
-            QLOG_DEBUG() << "Set userDataDir via command line to " + userDataDir;
+            userDataDir = parm;
+            QLOG_INFO() << "Set userDataDir via command line to " + userDataDir;
         }
 
 
@@ -367,9 +369,6 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
             command->setBit(STARTUP_GUI,true);
             guiAvailable = true;
         }
-
-
-
 
         if (command->at(STARTUP_ADDNOTE)) {
             if (parm.startsWith("--title=", Qt::CaseSensitive)) {
@@ -620,6 +619,12 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
                 sqlString = sqlString + " " + parm;
             }
         }
+    }
+
+    if ((!configDir.isEmpty()) && userDataDir.isEmpty()) {
+        QLOG_WARN() << "As you provided configDir but not provided userDataDir, userDataDir will fallback to configDir: "
+                       << configDir;
+        userDataDir = configDir;
     }
 
 

--- a/settings/startupconfig.cpp
+++ b/settings/startupconfig.cpp
@@ -30,11 +30,10 @@ extern Global global;
 
 StartupConfig::StartupConfig()
 {
-#ifdef USE_QSP
-    configDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/";
-#else
-    configDir = QDir().homePath() + QString("/.nixnote/");
-#endif
+    // we first allow command line override and set-up final directory later in global.setup()
+    configDir = QString("");
+    programDir = QString("");
+
     this->forceNoStartMinimized = false;
     this->startupNewNote = false;
     this->sqlExec = false;
@@ -256,8 +255,6 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
         guiAvailable = false;
 #endif // End windows check
 
-    QLOG_INFO() << "StartupConfig: configDir " << configDir;
-
     for (int i=1; i<argc; i++) {
         QString parm(argv[i]);
         if (parm == "--help" || parm == "-?" || parm == "help" || parm == "--?") {
@@ -273,12 +270,17 @@ int StartupConfig::init(int argc, char *argv[], bool &guiAvailable) {
         if (parm.startsWith("--accountId=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
             accountId = parm.toInt();
-            QLOG_DEBUG() << "Changed accountId via command line option to " + accountId;
+            QLOG_DEBUG() << "Set accountId via command line option to " + accountId;
         }
         if (parm.startsWith("--configDir=", Qt::CaseSensitive)) {
             parm = parm.section('=', 1, 1);
             configDir = parm;
-            QLOG_DEBUG() << "Changed configDir via command line to " + configDir;
+            QLOG_DEBUG() << "Set configDir via command line to " + configDir;
+        }
+        if (parm.startsWith("--programDir=", Qt::CaseSensitive)) {
+            parm = parm.section('=', 1, 1);
+            programDir = parm;
+            QLOG_DEBUG() << "Set programDir via command line to " + programDir;
         }
         if (parm.startsWith("addNote")) {
             command->setBit(STARTUP_ADDNOTE,true);

--- a/settings/startupconfig.h
+++ b/settings/startupconfig.h
@@ -62,10 +62,14 @@ private:
     void loadTheme(QString theme);
     QBitArray *command;
 
-    // stores startup info about directory of config files
+    // see FileManager.getConfigDir() for more info
     QString configDir;
-    // stores startup info about directory of program base
-    QString programDir;
+    QString programDataDir;
+    QString userDataDir;
+    // command line set log level
+    // this is used to check: if log leven was set on command line, then it overrides the conf file value
+    int logLevel;
+
     int accountId;
 
 public:
@@ -74,8 +78,14 @@ public:
     QString name;
 
     QString getConfigDir() { return configDir; }
-    QString getProgramDir() { return programDir; }
+    QString getProgramDataDir() { return programDataDir; }
+    QString getUserDataDir() { return userDataDir; }
+
+
     int getAccountId() { return accountId; }
+    int getLogLevel() { return logLevel; }
+
+    // TODO refactor its not very clean to set the account id here from "global"
     void setAccountId(int accountId);
 
     QString queryString;

--- a/settings/startupconfig.h
+++ b/settings/startupconfig.h
@@ -60,19 +60,28 @@ class StartupConfig
 {
 private:
     void loadTheme(QString theme);
-private:
     QBitArray *command;
+
+    // stores startup info about directory of config files
+    QString configDir;
+    // stores startup info about directory of program base
+    QString programDir;
+    int accountId;
 
 public:
     StartupConfig();
+
     QString name;
-    QString homeDirPath;
-    QString programDirPath;
+
+    QString getConfigDir() { return configDir; }
+    QString getProgramDir() { return programDir; }
+    int getAccountId() { return accountId; }
+    void setAccountId(int accountId);
+
     QString queryString;
     bool forceNoStartMinimized;
     bool startupNewNote;
     bool sqlExec;
-    int accountId;
     qint32 startupNoteLid;
     bool forceStartMinimized;
     bool enableIndexing;


### PR DESCRIPTION
hi,
I pulled an merged changes from your repo - regarding using standard config/data paths for nixnote (changes marked "USE_QSP"). I'm not sure from the repo history, whenever you are author or you taken it from some another fork.

I like the changes, I think they are improvement, but there were few problems:
* configDir parameter from command line was now ignored
* the if the program was not installed on standard location (e.g. local debug copy), it din't not worked at all
* the original code way already a bit sub-optimal by spreading the directory handling logic in three classes StartupConfig, Global, Filemanager, now it was even less obvious by using the #ifdefs
* it was breaking change for existing users having data already in home directory

So I refactored a bit and then more and more because I simply could not bring it to work and supoort all cases.

Fix:
* program has 3 directory paths "config dir", "program data dir" (like images), "user data" (database logs)
* all three can be given on commandline for non-standard cases - those have priority (logic is in StartupConfig)
* further directory handling logic is only in Filemanager (except for plugins and icons)
* then as fallback legacy config/data is checked: if it exist,s its used => backwards compatibility for existing users
* else standard paths are used (if nixnote is run out of standard binary path - this is taken - so running more versions on ony system is supported
* there is quite detailed logging of the applied logic, so if it breaks, it should be quite easy to find where
* I'm not sure, if I didn' break the "mac" logic, as I can't really check - but even if yes, it should now be much easier to fix now
* macro USE_QSP is removed, as it isn't needed anymore

so if you like to have the changes: here it is, else no problem either :)

![screen_20180616_02](https://user-images.githubusercontent.com/1135218/41499488-2ab797c2-7181-11e8-9044-f592e05b8d28.png)
